### PR TITLE
Unpin spire-agent-dracut to take the latest version published by COS

### DIFF
--- a/boxes/application/application.pkr.hcl
+++ b/boxes/application/application.pkr.hcl
@@ -157,7 +157,7 @@ build {
       "COS_CN_REPO=https://arti.hpc.amslabs.hpecorp.net/artifactory/cos-rpm-stable-local/release/cos-2.4/sle15_sp3_cn/ cray-cos-sle-15sp3-SHASTA-OS-cos-cn --no-gpgcheck -p 89 cray/cos/sle-15sp3-cn",
     ]
     inline        = [
-      "bash -c 'echo $COS_CN_REPO >> /srv/cray/csm-rpms/repos/cray.repos'",
+      "bash -c 'echo $COS_CN_REPO >> /srv/cray/csm-rpms/repos/cray.template.repos'",
       "bash -c 'cp /srv/cray/files/cmdline-perm.service /usr/lib/systemd/system/cmdline-perm.service'",
       "bash -c 'systemctl enable cmdline-perm'"
     ]

--- a/boxes/application/files/application.packages
+++ b/boxes/application/files/application.packages
@@ -1,1 +1,1 @@
-cray-spire-dracut=1.4.3
+cray-spire-dracut


### PR DESCRIPTION
The 0.2.1 image is missing spire-agent-dracut:
```
11:45:22  ==> qemu.application: zypper -n install --oldpackage --auto-agree-with-licenses --no-recommends 'cray-spire-dracut=1.4.3'
11:45:22      qemu.application: Loading repository data...
11:45:22      qemu.application: Warning: Repository 'buildonly-openSUSE-Backports-SLE-15-SP3-standard' appears to be outdated. Consider using a different mirror or server.
11:45:22      qemu.application: Warning: Repository 'buildonly-openSUSE-Backports-SLE-15-SP3-step' appears to be outdated. Consider using a different mirror or server.
11:45:22      qemu.application: Reading installed packages...
11:45:24  ==> qemu.application: No provider of 'cray-spire-dracut=1.4.3' found.
11:45:24      qemu.application: 'cray-spire-dracut=1.4.3' not found in package names. Trying capabilities.
```
This did not fail the build and so it was missed. The repo only contains the "latest" cray-spire-dracut, so unpin the version and accept the release version of this package from COS.